### PR TITLE
#92 Setup type checking script, etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "license": "license-check-and-add add -f license-config.json",
     "test": "jest test/ --passWithNoTests --detectOpenHandles",
     "deploy": "npm run lint && npm run test && npm run build && ncp .clasp-dev.json .clasp.json && clasp push -f",
-    "deploy:prod": "npm run lint && npm run test && npm run build && ncp .clasp-prod.json .clasp.json && clasp push"
+    "deploy:prod": "npm run lint && npm run test && npm run build && ncp .clasp-prod.json .clasp.json && clasp push",
+    "typeCheck": "tsc --noEmit"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
- **AFTER #81**
  - TypeScript の導入がされてないと動きません

# Ref Issues

- #92

# やったこと

- なんか Git の監視下に node_modules が居たので .gitignore を作っておいた
- scripts に `tsc --noEmit` を追加
  - 実施後は `npm run typeCheck` で動かせます

